### PR TITLE
Add support for Labs API

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -250,6 +250,8 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
     if (path.indexOf('media/') !== -1) {
       // For media/upload, use a different endpoint.
       reqOpts.url = endpoints.MEDIA_UPLOAD + path + '.json';
+    } else if (self.config.version) {
+      reqOpts.url = endpoints.API_HOST + self.config.version + '/' + path;
     } else {
       reqOpts.url = endpoints.REST_ROOT + path + '.json';
     }


### PR DESCRIPTION
To add the support for Twitter Developer Labs API, I added a config field— `version`, where we can input 'labs/2' to access the Developer Labs API.

Code:
```
const twit = new Twit({
  consumer_key: consumer_key,
  consumer_secret: consumer_secret,
  access_token: twitterAccessTokenKey,
  access_token_secret: twitterAccessTokenSecret,
  version: 'labs/2',
});
```