### PR TITLE
Add support for v2 tweets endpoint

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -37,6 +37,7 @@ var JSONPAYLOAD_PATHS = [
   'direct_messages/events/new',
   'direct_messages/welcome_messages/new',
   'direct_messages/welcome_messages/rules/new',
+  'tweets'
 ];
 
 //

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -250,6 +250,8 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
     if (path.indexOf('media/') !== -1) {
       // For media/upload, use a different endpoint.
       reqOpts.url = endpoints.MEDIA_UPLOAD + path + '.json';
+    } else if (self.config.version) {
+      reqOpts.url = endpoints.API_HOST + self.config.version + '/' + path;
     } else {
       reqOpts.url = endpoints.REST_ROOT + path + '.json';
     }


### PR DESCRIPTION
Adds support for the new V2 endpoints `tweets`, which needs the payload to have the Content-Type `application/json` .